### PR TITLE
Fix check-dist failing when nothing changes

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -55,5 +55,5 @@ jobs:
             git config --local user.name "github-actions[bot]"
             git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
             git fetch origin
-            git commit -m "Updating build files in dist/"
+            git commit -m "Updating build files in dist/" || echo "Nothing to commit"
             git push origin ${{github.event.pull_request.head.ref }}


### PR DESCRIPTION
Check-dist failed because `git commit` returns a non-zero exit code when there is nothing to commit.